### PR TITLE
Make jPlayer aware of stream format.

### DIFF
--- a/src/client/app.coffee
+++ b/src/client/app.coffee
@@ -1257,11 +1257,11 @@ handleResize = ->
   $playlist_items.height $pl_window.height() - $pl_header.position().top - $pl_header.height()
 
 initjPlayer = ->
-	$jplayer.jPlayer
-		swfPath: "/vendor/Jplayer.swf"
-		preload: "auto"
-		supplied: server_status.stream_httpd_format
-		solution: "flash, html"
+  $jplayer.jPlayer
+    swfPath: "/vendor/Jplayer.swf"
+    preload: "auto"
+    supplied: server_status.stream_httpd_format
+    solution: "flash, html"
 
 $document.ready ->
   socket = io.connect()
@@ -1327,10 +1327,5 @@ $document.ready ->
 
   # do this last so that everything becomes the correct size.
   $(window).resize handleResize
-
-  $jplayer.jPlayer
-    swfPath: "/vendor/Jplayer.swf"
-    preload: "auto"
-    solution: "flash, html"
 
   window._debug_mpd = mpd


### PR DESCRIPTION
Previously jPlayer was set to stream only mp3 by default. This defers
the initialisation of jPlayer until the server status object is ready,
then sets the format appropriately. This was previously causing ogg
streaming to fail silently.
