### PR TITLE
Added non-obvious build step when using npm and package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ Live discussion in #libgroove on Freenode.
 1. Install [Node.js](http://nodejs.org) v0.10.x.
 2. Install [libgroove](https://github.com/andrewrk/libgroove).
 3. Clone the source.
-4. `npm run build`
-5. `npm start`
+4. `npm install`
+5. `npm run build`
+6. `npm start`
 
 ## Screenshots
 


### PR DESCRIPTION
Seems like something that would be obvious, but the errors that Node spits our aren't very unhelpful.
Running `npm install` installs the dependencies listed in package.json so when you `npm start` it doesn't give generic `bindings file not found` or when it wants to be nice `cannot find module <package>`.
