### PR TITLE
Start at last play position on restart.

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -1222,17 +1222,13 @@ Player.prototype.play = function() {
 // This function should be avoided in favor of seek. Note that it is called by
 // some MPD protocol commands, because the MPD protocol is stupid.
 Player.prototype.seekToIndex = function(index, pos) {
-  this.currentTrack = this.tracksInOrder[index];
-  this.isPlaying = true;
-  this.groovePlaylist.play();
-  this.seekRequestPos = pos;
-  playlistChanged(this);
-  this.emit('currentTrack');
+  this.seek(this.tracksInOrder[index].id, pos);
 };
 
 Player.prototype.seek = function(id, pos) {
   this.currentTrack = this.playlist[id];
   this.isPlaying = true;
+  this.trackStartDate = new Date(new Date() - pos * 1000);
   this.groovePlaylist.play();
   this.seekRequestPos = pos;
   playlistChanged(this);


### PR DESCRIPTION
We now save the current seek offset for the currently playing track in the
database whenever the playlist changes. Then on startup we look for a track
with the offset set and seek to there. We still start paused though,
hopefully.

Currently when we change tracks I am not unsetting the pos of the previous
track but just unsetting the pos of all the tracks but the current. To do
otherwise would mean instrumenting all methods that change currentTrack.

I had to do some fiddling on checkUpdateGroovePlaylist() to get it to use
currentTrack.pos instead of seekRequestPos. I didn't look at all the code
paths that influence that point but it seems to work in testing (with the MPD
protocol anyway).

Todo on this branch:
- save playing/paused state too.
- catch ctrl-c and persistPlaylistItem(currentTrack); currently the seek position is only save when the playlist updated event is fired.
