### PR TITLE
Chrome waits for 2mb before playing song, leading to long buffering times

### DIFF
--- a/lib/groovebasin.js
+++ b/lib/groovebasin.js
@@ -44,6 +44,7 @@ var defaultConfig = {
   mpdHost: '0.0.0.0',
   mpdPort: 6600,
   acoustidAppKey: 'bgFvC4vW',
+  instantBufferBytes: 220 * 1024,
 };
 
 defaultConfig.permissions[genPassword()] = {
@@ -139,7 +140,7 @@ GrooveBasin.prototype.start = function() {
     self.initializeDownload();
     self.initializeUpload();
 
-    self.player = new Player(self.db, self.config.musicDirectory);
+    self.player = new Player(self.db, self.config.musicDirectory, self.config.instantBufferBytes);
     self.player.initialize(function(err) {
       if (err) {
         console.error("unable to initialize player:", err.stack);

--- a/lib/player.js
+++ b/lib/player.js
@@ -201,10 +201,6 @@ var OPEN_FILE_COUNT = 8;
 var PREV_FILE_COUNT = Math.floor(OPEN_FILE_COUNT / 2);
 var NEXT_FILE_COUNT = OPEN_FILE_COUNT - PREV_FILE_COUNT;
 
-// when a streaming client connects we send them many buffers quickly
-// in order to get the stream started, then we slow down.
-var instantBufferBytes = 220 * 1024;
-
 var DB_SCALE = Math.log(10.0) * 0.05;
 var REPLAYGAIN_PREAMP = 0.75;
 var REPLAYGAIN_DEFAULT = 0.25;
@@ -216,7 +212,7 @@ Player.REPEAT_ALL = 2;
 Player.trackWithoutIndex = trackWithoutIndex;
 
 util.inherits(Player, EventEmitter);
-function Player(db, musicDirectory) {
+function Player(db, musicDirectory, instantBufferBytes) {
   EventEmitter.call(this);
   this.setMaxListeners(0);
 
@@ -225,6 +221,10 @@ function Player(db, musicDirectory) {
   this.dbFilesByPath = {};
   this.libraryIndex = new MusicLibraryIndex();
   this.addQueue = new DedupedQueue({processOne: this.addToLibrary.bind(this)});
+  
+  // when a streaming client connects we send them many buffers quickly
+  // in order to get the stream started, then we slow down.
+  this.instantBufferBytes = instantBufferBytes;
 
   this.dirs = {};
   this.dirScanQueue = new DedupedQueue({
@@ -320,7 +320,7 @@ Player.prototype.initialize = function(cb) {
         // available or we get enough buffered
         while (1) {
           var bufferedSeconds = self.secondsIntoFuture(self.lastEncodeItem, self.lastEncodePos);
-          if (bufferedSeconds > 0.5 && self.recentBuffersByteCount >= instantBufferBytes) return;
+          if (bufferedSeconds > 0.5 && self.recentBuffersByteCount >= self.instantBufferBytes) return;
           var buf = self.grooveEncoder.getBuffer();
           if (!buf) return;
           if (buf.buffer) {
@@ -334,7 +334,7 @@ Player.prototype.initialize = function(cb) {
               self.recentBuffers.push(buf.buffer);
               self.recentBuffersByteCount += buf.buffer.length;
               while (self.recentBuffers.length > 0 &&
-                  self.recentBuffersByteCount - self.recentBuffers[0].length >= instantBufferBytes)
+                  self.recentBuffersByteCount - self.recentBuffers[0].length >= self.instantBufferBytes)
               {
                 self.recentBuffersByteCount -= self.recentBuffers.shift().length;
               }


### PR DESCRIPTION
Playing with groovebasin i'm getting about 1 minute buffering times before the stream actually starts
Digging into it I've determined its not groovebasin: wireshark shows data downloading immediately and curl will get data right away too
But chrome just shows this: 
![image](https://cloud.githubusercontent.com/assets/1075793/2812962/70070b16-ce77-11e3-8125-937e8a09486d.png)

It seems to be buffering waiting for 2mb of data before it acknowledges that it gets anything

It seems potentially related to these two issues
https://code.google.com/p/chromium/issues/detail?id=111281
https://code.google.com/p/chromium/issues/detail?id=128116

This pull request fixes it for me, but may exacerbate issues with song transitions.
I don't know enough about this project to know if it truly fixes the issue or not
