### PR TITLE
Don't write to streaming clients when we are paused.

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -338,8 +338,10 @@ Player.prototype.initialize = function(cb) {
               {
                 self.recentBuffersByteCount -= self.recentBuffers.shift().length;
               }
-              for (var i = 0; i < self.openStreamers.length; i += 1) {
-                self.openStreamers[i].write(buf.buffer);
+              if (self.isPlaying === true) {
+                for (var i = 0; i < self.openStreamers.length; i += 1) {
+                  self.openStreamers[i].write(buf.buffer);
+                }
               }
               self.lastEncodeItem = buf.item;
               self.lastEncodePos = buf.pos;
@@ -720,16 +722,24 @@ Player.prototype.streamMiddleware = function(req, resp, next) {
   resp.setHeader('Expires', '0');
   resp.statusCode = 200;
 
-  var count = 0;
-  self.headerBuffers.forEach(function(headerBuffer) {
-    count += headerBuffer.length;
-    resp.write(headerBuffer);
-  });
-  self.recentBuffers.forEach(function(recentBuffer) {
-    resp.write(recentBuffer);
-  });
-  console.log("sent", count, "bytes of headers and", self.recentBuffersByteCount,
-      "bytes of unthrottled data");
+  console.log("New streaming client connected from:",
+      req.ip+":"+req.connection.remotePort);
+
+  if (self.isPlaying === true) {
+    var count = 0;
+    self.headerBuffers.forEach(function(headerBuffer) {
+      count += headerBuffer.length;
+      resp.write(headerBuffer);
+    });
+    self.recentBuffers.forEach(function(recentBuffer) {
+      resp.write(recentBuffer);
+    });
+    console.log("sent", count, "bytes of headers and",
+        self.recentBuffersByteCount, "bytes of unthrottled data");
+  } else {
+    // Just send the HTTP headers.
+    resp.write("");
+  }
   self.openStreamers.push(resp);
   req.on('abort', function() {
     for (var i = 0; i < self.openStreamers.length; i += 1) {


### PR DESCRIPTION
This was causing clients that connected to the stream while the player was
paused to get sent the buffer of the last played audio. Quite uselessly
because there is no reason to full up their cache if they are just going to go
ahead and empty it again.

Maybe the cache of recent audio should be flushed on seek too? Else when you connect right around a seek event you will get a burst of audio from before the seek, which is the same as the clients already connected but isn't helpful. Also, I am not sure if it is cleared or not on pause and stop.
