### PR TITLE
Adds dependencies section to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ $ npm run dev
 This will install dependencies, build generated files, and then start the
 sever. It is up to you to restart it when you modify assets or server files.
 
+## Dependencies
+
+The `npm run build` might fail if you system does not contain the following dependencies : 
+
+ * [g++](http://gcc.gnu.org/). On ubuntu, this is as simple as running
+   ```sudo apt-get install g++``` 
+
 ### Community
 
 Pull requests, feature requests, and bug reports are welcome! Live discussion


### PR DESCRIPTION
During the installation yesterday, npm build failed due to g++ missing on my system .
It might be worth writing a line about it being a dependency, so that people can know how to fix.

I didn't want to reduce the wow factor of the 5 steps install in the installation section, so I decided to create a dependencies section instead.
The dependency was on groovebasin itself, not libgroove.
