### PR TITLE
Changed doc link to redirect locally.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,9 +8,11 @@ Groove Basin: the ultimate music player
 
 Welcome to the documentation for Groove Basin, a music player with a web-based user interface inspired by Amarok 1.4..
 
-If you're new to Groove Basin, begin with the :doc:`guides/main` guide. That guide walks you through installing Groove Basin, setting it up how you like it, and starting to build your music library.
+If you're new to Groove Basin, begin with the `:docs:guides/main`_ guide. That guide walks you through installing Groove Basin, setting it up how you like it, and starting to build your music library.
 
 If you still need help, your can drop by the #libgroove IRC channel on Freenode or file a bug in the issue tracker. Please let us know where you think this documentation can be improved.
+
+.. _:docs:guides/main: guides/main.rst
 
 Contents:
 


### PR DESCRIPTION
URI abbreviations don't appear to work with Github.
Is there a preferred doc linking methodology and format you want to stick with?
