### PR TITLE
skip non-audio when scanning library for new content

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -18,6 +18,7 @@ var safePath = require('./safe_path');
 var PassThrough = require('stream').PassThrough;
 var url = require('url');
 var superagent = require('superagent');
+var mime = require('mime');
 
 module.exports = Player;
 
@@ -649,6 +650,14 @@ Player.prototype.refreshFilesIndex = function(args, cb) {
         return;
       }
     }
+    
+    // Only add audio content.
+    var mimetype = mime.lookup(relPath);
+    if ('audio' != mimetype.split('/')[0]) {
+      console.error("ignore non audio file: ", relPath);
+      return;
+    }
+
     self.addQueue.add(relPath, {
       relPath: relPath,
       mtime: fileMtime,

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ytdl": "^0.2.4",
     "serve-static": "^1.0.3",
     "body-parser": "^1.0.1",
+    "mime": "^1.2.11",
     "semver": "^2.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I have a number of non audio files interspersed in my audio library: cover images, lyrics... And every time I start Groove Basin, it tries to add those to the library, slowing down the startup process and generating a number of warnings/errors. This patch adds a quick MIME type based check to filter and scan audio content only.

N.B.: the [mime](https://github.com/broofa/node-mime) library check is extension based only. If a content check is preferable then one option would be to use  [mmmagic](https://github.com/mscdex/mmmagic).
