### PR TITLE
Dummy Fallback Fix

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -357,15 +357,15 @@ Player.prototype.initialize = function(cb) {
       }
       startupTrackInfo = options.currentTrackInfo;
       var hardwarePlaybackValue = options.hardwarePlayback == null ? true : options.hardwarePlayback;
-      // start the dummy first so that we fall back to it if the second one fails
-      self.setHardwarePlayback(false, function(err) {
-        if (err) return cb(err);
-        self.setHardwarePlayback(hardwarePlaybackValue, function(err) {
-          if (err) {
-            console.error("Unable to attach hardware player, falling back to dummy.", err.stack);
-          }
-          cb();
-        });
+      // start the hardware player first
+      // fall back to dummy
+      self.setHardwarePlayback(hardwarePlaybackValue, function(err) {
+        if (err) {
+          console.error("Unable to attach hardware player, falling back to dummy.", err.stack);
+          self.setHardwarePlayback(false, function(err) {
+              if(err) return cb(err);
+          });
+        }
       });
     });
 
@@ -790,8 +790,8 @@ function startPlayerSwitchDevice(self, wantHardware, cb) {
     self.groovePlayer = groove.createPlayer();
     self.groovePlayer.deviceIndex = wantHardware ? null : groove.DUMMY_DEVICE;
     self.groovePlayer.attach(self.groovePlaylist, function(err) {
-      if (err) return cb(err);
       self.pendingPlayerAttachDetach = false;
+      if (err) return cb(err);
       if (self.desiredPlayerHardwareState !== wantHardware) {
         startPlayerSwitchDevice(self, self.desiredPlayerHardwareState, cb);
       } else {


### PR DESCRIPTION
This is for issue #272

It looks like there were two causes for that issue. If the groovePlayer object failed to attach to a device, it would return with an error but leave the "pending attachDetach" flag set to true, so on subsequent attempts to attach to a dummy device or new hardware, the function would just return immediately. I changed the function to set the flag to false before returning in the case of an error.

The other cause was initializing the dummy first. When trying to attach to hardware, before trying to attach, groovePlayer was detaching from all devices. So the dummy device would get detached, then the hardware would fail, so groovePlayer would wind up not attached to anything. I changed the order to try hardware first, then initialize the dummy device if the hardware fails.

Everything seems to be working correctly in my soundcard-less environment.
