### PR TITLE
use npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Try out the [live demo](http://demo.groovebasin.com/).
    or compile from source.
 2. Install [libgroove](https://github.com/andrewrk/libgroove).
 3. Clone the source and cd to it.
-4. `npm run build`
+4. `npm install`
 5. `npm start`
 
 ## Configuration

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "scripts": {
     "start": "node lib/server.js",
-    "build": "npm install && ./build",
+    "postinstall": "./build",
     "dev": "npm run build && npm start"
   }
 }


### PR DESCRIPTION
I changed `npm run build` to `npm install` and instead using the `postinstall` for the build step, which is automatically run by npm after the dependencies are installed.
