### PR TITLE
don't crash on failed download

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -18,5 +18,7 @@ function download(urlString, cb) {
   parsedUrl.rejectUnauthorized = false;
   httpLib.get(parsedUrl, function(res) {
     cb(null, res);
+  }).on('error', function(err) {
+    cb(err, null);
   });
 }


### PR DESCRIPTION
Currently, a user can crash the server by telling it to import a song from a URL such as "http://nonexistent.example.com". This patch handles the error and prevents the crash.
