### PR TITLE
Open stream and homepage links in new tabs/windows

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -181,8 +181,8 @@
         <div class="section">
           <h1>About</h1>
           <ul>
-            <li><a id="settings-stream-url" href="#">Stream URL</a></li>
-            <li><a href="http://github.com/andrewrk/groovebasin">GrooveBasin on GitHub</a></li>
+            <li><a id="settings-stream-url" href="#" target="_blank">Stream URL</a></li>
+            <li><a href="http://github.com/andrewrk/groovebasin" target="_blank">GrooveBasin on GitHub</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
Otherwise we "close" the app, which is uncool

I didn't touch the lastfm link because presumably one needs to restart the app anyway.
