### PR TITLE
Seek bar causes high CPU usage - Add check to prevent excessive browser repaints on seek bar

### DIFF
--- a/src/client/app.js
+++ b/src/client/app.js
@@ -1888,28 +1888,45 @@ function getCurrentTrackPosition(){
   }
 }
 
-function updateSliderPos() {
-  window.requestAnimationFrame(updateSliderPos);
 
+function updateSliderPos() {
   if (userIsSeeking) return;
 
-  var duration, disabled, elapsed, sliderPos;
-  if (player.currentItem && player.isPlaying != null && player.currentItem.track) {
-    disabled = false;
-    elapsed = getCurrentTrackPosition();
-    duration = player.currentItem.track.duration;
-    sliderPos = elapsed / duration;
-  } else {
-    disabled = true;
-    elapsed = duration = sliderPos = 0;
+  var lastUpdate = 0;
+
+  function doUpdate(timestamp) {
+    var duration, 
+      disabled, 
+      elapsed, 
+      sliderPos, 
+      updateInterval = 1000;
+
+    if (player.currentItem && player.isPlaying != null && player.currentItem.track) {
+      disabled = false;
+      elapsed = getCurrentTrackPosition();
+      duration = player.currentItem.track.duration;
+      sliderPos = elapsed / duration;
+    } else {
+      disabled = true;
+      elapsed = duration = sliderPos = 0;
+    }
+
+    // update only at 1000ms intervals to prevent unnecessary browser repaints
+    if (timestamp > lastUpdate + updateInterval) {
+      trackSliderDom.disabled = disabled;
+      trackSliderDom.value = sliderPos;
+      updateSliderUi();
+
+      nowPlayingElapsedDom.textContent = formatTime(elapsed);
+      nowPlayingLeftDom.textContent = formatTime(duration);
+
+      lastUpdate = timestamp;
+    }
+
+    window.requestAnimationFrame(doUpdate);
   }
 
-  trackSliderDom.disabled = disabled;
-  trackSliderDom.value = sliderPos;
-  updateSliderUi();
-
-  nowPlayingElapsedDom.textContent = formatTime(elapsed);
-  nowPlayingLeftDom.textContent = formatTime(duration);
+  doUpdate();
 }
 
 function renderVolumeSlider() {


### PR DESCRIPTION
The seek bar and elapsed time are updated at 60 times a second (assuming 60 FPS) which causes excessive CPU usage. This could be changed to update at 1 time per second.

I've created a function inside `updateSliderPos()`, alternatively you could add `var lastUpdate` to the outer scope. 

More on repaint / reflows:
https://developers.google.com/speed/articles/reflow
http://addyosmani.com/blog/devtools-visually-re-engineering-css-for-faster-paint-times/