### PR TITLE
things ought not jump around when you hover over them

### DIFF
--- a/src/client/styles/app.styl
+++ b/src/client/styles/app.styl
@@ -300,6 +300,7 @@ button:hover .icon
       font-size 13px
       border-top-left-radius 4px
       border-top-right-radius 4px
+      border 1px solid transparent
 
       &.active, &.active:hover
         border 1px solid #096ac8


### PR DESCRIPTION
The tabs jump because hovering over them adds a border to them,
changing their width. This adds an invisible border to all of the
tabs, so hovering only needs to change the border color.

Thanks!