### PR TITLE
Changes for groove 3.0

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -885,7 +885,13 @@ function startPlayerSwitchDevice(self, wantHardware, cb) {
   function onDetachComplete(err) {
     if (err) return cb(err);
     self.groovePlayer = groove.createPlayer();
-    self.groovePlayer.deviceIndex = wantHardware ? null : groove.DUMMY_DEVICE;
+
+    groove.connectSoundBackend();
+    var devices = groove.getDevices();
+    var defaultDevice = devices.list[devices.defaultIndex];
+    self.groovePlayer.device = defaultDevice;
+
+    //self.groovePlayer.deviceIndex = wantHardware ? null : groove.DUMMY_DEVICE;
     self.groovePlayer.attach(self.groovePlaylist, function(err) {
       self.pendingPlayerAttachDetach = false;
       if (err) return cb(err);
@@ -911,7 +917,7 @@ Player.prototype.setHardwarePlayback = function(value, cb) {
 
     self.clearEncodedBuffer();
     self.emit('seek');
-    self.groovePlayer.on('nowplaying', onNowPlaying);
+    self.groovePlayer.on('nowPlaying', onNowPlaying);
     self.persistOption('hardwarePlayback', self.desiredPlayerHardwareState);
     self.emit('hardwarePlayback', self.desiredPlayerHardwareState);
     cb();
@@ -2626,8 +2632,7 @@ function checkUpdateGroovePlaylist(self) {
       // if they're the same, we advance
       // but we might have to correct the gain
       gainAndPeak = calcGainAndPeak(plTrack);
-      self.groovePlaylist.setItemGain(grooveItem, gainAndPeak.gain);
-      self.groovePlaylist.setItemPeak(grooveItem, gainAndPeak.peak);
+      self.groovePlaylist.setItemGainPeak(grooveItem, gainAndPeak.gain, gainAndPeak.peak);
       currentGrooveItem = currentGrooveItem || grooveItem;
       groovePlIndex += 1;
       incrementPlIndex();


### PR DESCRIPTION
I'm not sure what to do about the dummy switch, but if you can point me in the right direction I should be able to pull it off :)

Oddly, I was able to get most things building under node 7.5.0 with the older libgroove, but the 100% cpu thing irked me off and I can't readily troubleshoot the C/C++ bits that were making this crash on the new builds, so this doesn't do anything about requiring a super old node (0.12 was what I got it working with)